### PR TITLE
Merge develop into master

### DIFF
--- a/src/ItemCollection.php
+++ b/src/ItemCollection.php
@@ -45,6 +45,20 @@ abstract class ItemCollection extends BaseCollection implements JsonSerializable
   {
     return new static($items, $parent);
   }
+  
+  /**
+   * @return ReactiveObject|ItemCollection|null
+   */
+  public function getRootParent()
+  {
+    $parent = $this->parent;
+    
+    while (!empty($parent->parent)) {
+      $parent = $parent->parent;
+    }
+    
+    return $parent;
+  }
 
   /**
    * Set the item at a given offset.

--- a/src/ItemCollection.php
+++ b/src/ItemCollection.php
@@ -10,7 +10,7 @@ abstract class ItemCollection extends BaseCollection implements JsonSerializable
   use Hooks;
 
   /** @var ReactiveObject|ItemCollection|null */
-  protected $parent = null;
+  public $parent = null;
 
   /** @var string */
   protected static $type = ReactiveObject::class;

--- a/src/ReactiveObject.php
+++ b/src/ReactiveObject.php
@@ -15,7 +15,7 @@ abstract class ReactiveObject implements ArrayAccess, JsonSerializable
   use Accessors;
 
   /** @var ReactiveObject|ItemCollection|null */
-  protected $parent = null;
+  public $parent = null;
 
   /** @var array */
   protected $defaults = [];
@@ -62,6 +62,20 @@ abstract class ReactiveObject implements ArrayAccess, JsonSerializable
   public function getParent()
   {
     return $this->parent;
+  }
+  
+  /**
+   * @return ReactiveObject|ItemCollection|null
+   */
+  public function getRootParent()
+  {
+    $parent = $this->parent;
+    
+    while (!empty($parent->parent)) {
+      $parent = $parent->parent;
+    }
+    
+    return $parent;
   }
 
   /**


### PR DESCRIPTION
Makes the `$parent` property public, and implements `getRootParent()` method in ReactiveObject and ItemCollection